### PR TITLE
Refac: 해설 api 호출 후 해설화면 전환까지 시간 줄임

### DIFF
--- a/lib/describe_page.dart
+++ b/lib/describe_page.dart
@@ -1,47 +1,118 @@
 import 'dart:io';
+import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'describe_box.dart';
+import 'package:http/http.dart' as http;
 import 'success_dialog.dart';
+import 'fail_dialog.dart';
+import 'describe_box.dart';
+import 'utils/auth_storage.dart';
 
-class DescribePage extends StatelessWidget {
+class DescribePage extends StatefulWidget {
   final String imagePath;
-  final String? title;
-  final String? artist;
-  final String? year;
-  final String? description;
-  final String? imageUrl;
 
   const DescribePage({
     super.key,
     required this.imagePath,
-    this.title,
-    this.artist,
-    this.year,
-    this.description,
-    this.imageUrl,
   });
+
+  @override
+  State<DescribePage> createState() => _DescribePageState();
+}
+
+class _DescribePageState extends State<DescribePage> {
+  bool _showSuccessDialog = true;
+  bool _hasFailed = false;
+  Map<String, dynamic>? _artData;
+
+  @override
+  void initState() {
+    super.initState();
+    _startRecognition();
+  }
+
+  Future<void> _startRecognition() async {
+    final uri = Uri.parse("http://43.203.23.173:8080/recog/analyzeAndRegister");
+    final token = await getJwtToken();
+    if (token == null) {
+      _showFailure();
+      return;
+    }
+
+    var request = http.MultipartRequest("POST", uri);
+    request.headers['Authorization'] = 'Bearer $token';
+    request.files.add(await http.MultipartFile.fromPath('file', widget.imagePath));
+
+    try {
+      final response = await request.send();
+      final responseBody = await response.stream.bytesToString();
+      final statusCode = response.statusCode;
+
+      if (!mounted) return;
+
+      if (statusCode == 200) {
+        final data = json.decode(responseBody);
+        setState(() {
+          _artData = {
+            "title": data['gemini_result']['title'] ?? '정보 없음',
+            "artist": data['gemini_result']['artist'] ?? '정보 없음',
+            "year": data['gemini_result']['year'] ?? '',
+            "description": data['gemini_result']['description'] ?? '',
+            "imageUrl": data['original_image_url'] ?? '',
+          };
+        });
+      } else {
+        print('❌ 응답 실패 - 상태코드: $statusCode');
+        _showFailure();
+      }
+    } catch (e) {
+      print('❌ 예외 발생: $e');
+      _showFailure();
+    }
+  }
+
+  void _showFailure() {
+    if (!mounted) return;
+    setState(() {
+      _showSuccessDialog = false;
+      _hasFailed = true;
+    });
+  }
+
+  void _onSuccessDialogCompleted() {
+    if (_artData != null) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (context) => DescriptionScreen(
+            title: _artData!['title'],
+            artist: _artData!['artist'],
+            year: _artData!['year'],
+            description: _artData!['description'],
+            imagePath: widget.imagePath,
+            imageUrl: _artData!['imageUrl'],
+            scrollController: ScrollController(),
+          ),
+        ),
+      );
+    } else {
+      // 아직 응답이 안 왔다면 대기
+      Future.delayed(const Duration(seconds: 1), _onSuccessDialogCompleted);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.transparent,
-      body: SuccessDialog(
-        onCompleted: () {
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-              builder: (context) => DescriptionScreen(
-                title: title ?? '정보 없음',
-                artist: artist ?? '정보 없음',
-                year: year ?? '',
-                description: description ?? '',
-                imagePath: imagePath,
-                imageUrl: imageUrl ?? '',
-                scrollController: ScrollController(),
-              ),
+      body: Stack(
+        children: [
+          if (_showSuccessDialog)
+            SuccessDialog(onCompleted: _onSuccessDialogCompleted),
+          if (_hasFailed)
+            const Center(
+              child: FailDialog(),
             ),
-          );
-        },
+        ],
       ),
     );
   }


### PR DESCRIPTION
## 📌연관된 이슈 번호
ex) #1

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
Refac: 해설 api 호출 후 바로 successdialog 뜸 -> api 실행 완료 후 해설화면 전환(캡처부터 해설화면 전환까지 15초 이내)

## 💬리뷰 포인트 (선택)
ex) method 이름이 잘 생각이 안 나는데 추천해 주실 거 있으신가요?

## 테스트 결과 (선택)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
